### PR TITLE
Generalize helpers to Attribute msg

### DIFF
--- a/src/Accessibility.elm
+++ b/src/Accessibility.elm
@@ -415,7 +415,7 @@ checkbox value_ maybeChecked attributes =
 -}
 tabList : List (Attribute Never) -> List (Html msg) -> Html msg
 tabList attributes =
-    Html.div (nonInteractive (Role.tabList :: attributes))
+    Html.div (Role.tabList :: nonInteractive attributes)
 
 
 {-| Create a tab. This is the part that you select in order to change panel views.
@@ -424,14 +424,14 @@ the right and left keys on their keyboards, they expect for the selected tab to 
 -}
 tab : List (Attribute msg) -> List (Html msg) -> Html msg
 tab attributes =
-    Html.div (nonInteractive [ Key.tabbable True, Role.tab ] ++ attributes)
+    Html.div (Role.tab :: Key.tabbable True :: attributes)
 
 
 {-| Create a tab panel.
 -}
 tabPanel : List (Attribute Never) -> List (Html msg) -> Html msg
 tabPanel attributes =
-    Html.div (nonInteractive (Role.tabPanel :: attributes))
+    Html.div (Role.tabPanel :: nonInteractive attributes)
 
 
 

--- a/src/Accessibility/Aria.elm
+++ b/src/Accessibility/Aria.elm
@@ -75,7 +75,7 @@ import Html.Attributes exposing (..)
 {-| Creates aria labelledby attribute. Pass the unique string id of the labelling element.
 `labeledBy` and `labelledBy` are identical.
 -}
-labeledBy : String -> Html.Attribute Never
+labeledBy : String -> Html.Attribute msg
 labeledBy =
     labelledBy
 
@@ -83,7 +83,7 @@ labeledBy =
 {-| Creates aria labelledby attribute. Pass the unique string id of the labelling element.
 `labeledBy` and `labelledBy` are identical.
 -}
-labelledBy : String -> Html.Attribute Never
+labelledBy : String -> Html.Attribute msg
 labelledBy =
     attribute "aria-labelledby"
 
@@ -100,7 +100,7 @@ labelledBy =
             [ longDescription "/quarter_4_summary#Growth" ]
 
 -}
-longDescription : String -> Html.Attribute Never
+longDescription : String -> Html.Attribute msg
 longDescription =
     attribute "longdesc"
 
@@ -112,7 +112,7 @@ longDescription =
 Identifies the currently-active element.
 
 -}
-activeDescendant : String -> Html.Attribute Never
+activeDescendant : String -> Html.Attribute msg
 activeDescendant =
     aria "activedescendant"
 
@@ -125,7 +125,7 @@ displayed. (If all columns are present--skip using this.)
 `-1` indicates total column number is unknown.
 
 -}
-colCount : Int -> Html.Attribute Never
+colCount : Int -> Html.Attribute msg
 colCount =
     aria "colcount" << toString
 
@@ -138,7 +138,7 @@ If a cell stretches across multiple columns, use the starting column index and `
 The simplest rule is to put the `colIndex` on every child of a `row`.
 
 -}
-colIndex : Int -> Html.Attribute Never
+colIndex : Int -> Html.Attribute msg
 colIndex =
     aria "colindex" << toString
 
@@ -148,7 +148,7 @@ colIndex =
 Indicate how many columns-wide a cell is.
 
 -}
-colSpan : Int -> Html.Attribute Never
+colSpan : Int -> Html.Attribute msg
 colSpan =
     aria "colspan" << toString
 
@@ -161,7 +161,7 @@ displayed. (If all rows are present--skip using this.)
 `-1` indicates total row number is unknown.
 
 -}
-rowCount : Int -> Html.Attribute Never
+rowCount : Int -> Html.Attribute msg
 rowCount =
     aria "rowcount" << toString
 
@@ -171,7 +171,7 @@ rowCount =
 Analagous to `colIndex`.
 
 -}
-rowIndex : Int -> Html.Attribute Never
+rowIndex : Int -> Html.Attribute msg
 rowIndex =
     aria "rowindex" << toString
 
@@ -181,7 +181,7 @@ rowIndex =
 Indicate how many rows-wide a cell is.
 
 -}
-rowSpan : Int -> Html.Attribute Never
+rowSpan : Int -> Html.Attribute msg
 rowSpan =
     aria "rowspan" << toString
 
@@ -192,7 +192,7 @@ rowSpan =
 Only necessary when not all of the items in the set are in the DOM. Use with `setSize`.
 
 -}
-posInSet : Int -> Html.Attribute Never
+posInSet : Int -> Html.Attribute msg
 posInSet =
     aria "posinset" << toString
 
@@ -204,14 +204,14 @@ posInSet =
 currently present in the DOM.
 
 -}
-setSize : Int -> Html.Attribute Never
+setSize : Int -> Html.Attribute msg
 setSize =
     aria "setsize" << toString
 
 
 {-| Creates aria controls attribute. Pass the unique string id of whatever is being controlled.
 -}
-controls : String -> Html.Attribute Never
+controls : String -> Html.Attribute msg
 controls =
     aria "controls"
 
@@ -221,7 +221,7 @@ controls =
 Indicate that a link in a nav or list is the current location.
 
 -}
-currentPage : Html.Attribute Never
+currentPage : Html.Attribute msg
 currentPage =
     aria "current" "page"
 
@@ -231,14 +231,14 @@ currentPage =
 Indicate which step in a step-based flow is the current one.
 
 -}
-currentStep : Html.Attribute Never
+currentStep : Html.Attribute msg
 currentStep =
     aria "current" "step"
 
 
 {-| Supported by all elements.
 -}
-currentLocation : Html.Attribute Never
+currentLocation : Html.Attribute msg
 currentLocation =
     aria "current" "location"
 
@@ -248,7 +248,7 @@ currentLocation =
 As in a calendar widget.
 
 -}
-currentDate : Html.Attribute Never
+currentDate : Html.Attribute msg
 currentDate =
     aria "current" "date"
 
@@ -258,14 +258,14 @@ currentDate =
 As in a timepicker widget.
 
 -}
-currentTime : Html.Attribute Never
+currentTime : Html.Attribute msg
 currentTime =
     aria "current" "time"
 
 
 {-| Supported by all elements.
 -}
-currentItem : Bool -> Html.Attribute Never
+currentItem : Bool -> Html.Attribute msg
 currentItem =
     aria "current" << toBoolString
 
@@ -276,7 +276,7 @@ Kind of a more-verbose version of `labelledBy`. Pass it a list of ids
 of elements that describe the given element.
 
 -}
-describedBy : List String -> Html.Attribute Never
+describedBy : List String -> Html.Attribute msg
 describedBy =
     aria "describedby" << toListString
 
@@ -287,7 +287,7 @@ Refer to a single extended description section--maybe a couple of paragraphs
 and a chart. Pass in the section's id.
 
 -}
-details : String -> Html.Attribute Never
+details : String -> Html.Attribute msg
 details =
     aria "details"
 
@@ -301,7 +301,7 @@ is telling the user in what way their submission is wrong.
     input [ invalid True, errorMessage "error-message-id" ] []
 
 -}
-errorMessage : String -> Html.Attribute Never
+errorMessage : String -> Html.Attribute msg
 errorMessage =
     aria "errormessage"
 
@@ -312,7 +312,7 @@ Provide an alternative document reading order and offer navigation to the
 elements referenced in the passed-in list of ids.
 
 -}
-flowTo : List String -> Html.Attribute Never
+flowTo : List String -> Html.Attribute msg
 flowTo =
     aria "flowto" << toListString
 
@@ -325,7 +325,7 @@ on how to make good shortcuts.
     keyShortcuts [ "Alt+Shift+P", "Control+F" ]
 
 -}
-keyShortcuts : List String -> Html.Attribute Never
+keyShortcuts : List String -> Html.Attribute msg
 keyShortcuts =
     aria "keyshortcuts" << toListString
 
@@ -335,7 +335,7 @@ keyShortcuts =
 Provide a hint about an expected value.
 
 -}
-placeholder : String -> Html.Attribute Never
+placeholder : String -> Html.Attribute msg
 placeholder =
     aria "placeholder"
 
@@ -346,6 +346,6 @@ Provide human-readable description of the role of an element. Should be used
 alongside an actual role--this is supplementary information.
 
 -}
-roleDescription : String -> Html.Attribute Never
+roleDescription : String -> Html.Attribute msg
 roleDescription =
     aria "roledescription"

--- a/src/Accessibility/Key.elm
+++ b/src/Accessibility/Key.elm
@@ -63,7 +63,7 @@ explicitly, but you may want to restructure your HTML to match how you want
 users to interact with it instead.
 
 -}
-tabbable : Bool -> Attribute Never
+tabbable : Bool -> Attribute msg
 tabbable isTabbable =
     if isTabbable then
         Html.Attributes.tabindex 0

--- a/src/Accessibility/Landmark.elm
+++ b/src/Accessibility/Landmark.elm
@@ -51,7 +51,7 @@ affect this default behavior, please check out [W3](https://www.w3.org/TR/wai-ar
             ]
 
 -}
-banner : Html.Attribute Never
+banner : Html.Attribute msg
 banner =
     role Banner
 
@@ -85,7 +85,7 @@ to see a real example of using the complementary role!
             ]
 
 -}
-complementary : Html.Attribute Never
+complementary : Html.Attribute msg
 complementary =
     role Complementary
 
@@ -103,7 +103,7 @@ a `section` or `main` or what-have-you (see [W3](https://www.w3.org/TR/wai-aria-
         ]
 
 -}
-contentInfo : Html.Attribute Never
+contentInfo : Html.Attribute msg
 contentInfo =
     role Contentinfo
 
@@ -113,7 +113,7 @@ contentInfo =
 For examples, please see [W3](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/form.html).
 
 -}
-form : Html.Attribute Never
+form : Html.Attribute msg
 form =
     role Form
 
@@ -124,7 +124,7 @@ one element with role main, make sure each is labeled. See [W3](https://www.w3.o
 HTML5's `main` tag is implicitly role `main`.
 
 -}
-main_ : Html.Attribute Never
+main_ : Html.Attribute msg
 main_ =
     role Main
 
@@ -138,7 +138,7 @@ this list?). For examples of how to do this using the `labeledBy` property,
 check out [W3](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/navigation.html).
 
 -}
-navigation : Html.Attribute Never
+navigation : Html.Attribute msg
 navigation =
     role Navigation
 
@@ -169,7 +169,7 @@ As ever, if there's more than one search element on the page, please be sure to 
             ]
 
 -}
-search : Html.Attribute Never
+search : Html.Attribute msg
 search =
     role Search
 
@@ -177,13 +177,13 @@ search =
 {-| Declare a region as a web application.
 Be careful with this one--see <https://www.w3.org/TR/WCAG20-TECHS/ARIA11.html>.
 -}
-application : Html.Attribute Never
+application : Html.Attribute msg
 application =
     role Application
 
 
 {-| Prefer the other Landmark options to `region`. Be sure to add a name when using this attribute!
 -}
-region : Html.Attribute Never
+region : Html.Attribute msg
 region =
     role Region

--- a/src/Accessibility/Live.elm
+++ b/src/Accessibility/Live.elm
@@ -37,7 +37,7 @@ region doesn't have focus. When `True`, all the contents of the element will be
 presented to the user.
 
 -}
-atomic : Bool -> Html.Attribute Never
+atomic : Bool -> Html.Attribute msg
 atomic =
     aria "atomic" << toBoolString
 
@@ -48,7 +48,7 @@ When set to `True`, this is the aria equivalent of a loading spinner--indicates
 that stuff is changing/is not ready for interaction/reading-off yet.
 
 -}
-busy : Bool -> Html.Attribute Never
+busy : Bool -> Html.Attribute msg
 busy =
     aria "busy" << toBoolString
 
@@ -59,7 +59,7 @@ When the region's contents change, assistive technologies will wait for a good
 moment to interrupt and do so politely with the update.
 
 -}
-livePolite : Html.Attribute Never
+livePolite : Html.Attribute msg
 livePolite =
     aria "live" "polite"
 
@@ -70,7 +70,7 @@ Updates to the region will cause the assistive technologies to immediately
 interrupt the user with the big news.
 
 -}
-liveAssertive : Html.Attribute Never
+liveAssertive : Html.Attribute msg
 liveAssertive =
     aria "live" "assertive"
 
@@ -80,7 +80,7 @@ liveAssertive =
 Keep track of additions to the live region.
 
 -}
-relevantAdditions : Html.Attribute Never
+relevantAdditions : Html.Attribute msg
 relevantAdditions =
     aria "relevant" "additions"
 
@@ -90,7 +90,7 @@ relevantAdditions =
 Keep track of node additions to the live region and text additions.
 
 -}
-relevantAdditionsText : Html.Attribute Never
+relevantAdditionsText : Html.Attribute msg
 relevantAdditionsText =
     aria "relevant" "additions text"
 
@@ -100,7 +100,7 @@ relevantAdditionsText =
 Keep track of everything to occur in the live region. Use sparingly!
 
 -}
-relevantAll : Html.Attribute Never
+relevantAll : Html.Attribute msg
 relevantAll =
     aria "relevant" "all"
 
@@ -110,7 +110,7 @@ relevantAll =
 Keep track of text or node removals. Use sparingly!
 
 -}
-relevantRemovals : Html.Attribute Never
+relevantRemovals : Html.Attribute msg
 relevantRemovals =
     aria "relevant" "removals"
 
@@ -120,6 +120,6 @@ relevantRemovals =
 Keep track of text additions to the live region.
 
 -}
-relevantText : Html.Attribute Never
+relevantText : Html.Attribute msg
 relevantText =
     aria "relevant" "text"

--- a/src/Accessibility/Role.elm
+++ b/src/Accessibility/Role.elm
@@ -138,105 +138,105 @@ import Html.Attributes
     div [ custom "tablist" ] [ tab1, tab2 ]
 
 -}
-custom : String -> Html.Attribute Never
+custom : String -> Html.Attribute msg
 custom =
     Html.Attributes.attribute "role"
 
 
 {-| Add `role="alert"` to the attributes of an element.
 -}
-alert : Html.Attribute Never
+alert : Html.Attribute msg
 alert =
     role Alert
 
 
 {-| Add `role="alertdialog"` to the attributes of an element.
 -}
-alertDialog : Html.Attribute Never
+alertDialog : Html.Attribute msg
 alertDialog =
     role Alertdialog
 
 
 {-| Add `role="article"` to the attributes of an element.
 -}
-article : Html.Attribute Never
+article : Html.Attribute msg
 article =
     role Article
 
 
 {-| Add `role="button"` to the attributes of an element.
 -}
-button : Html.Attribute Never
+button : Html.Attribute msg
 button =
     role Button
 
 
 {-| Add `role="checkbox"` to the attributes of an element.
 -}
-checkBox : Html.Attribute Never
+checkBox : Html.Attribute msg
 checkBox =
     role Checkbox
 
 
 {-| Add `role="columnheader"` to the attributes of an element.
 -}
-columnHeader : Html.Attribute Never
+columnHeader : Html.Attribute msg
 columnHeader =
     role Columnheader
 
 
 {-| Add `role="combobox"` to the attributes of an element.
 -}
-comboBox : Html.Attribute Never
+comboBox : Html.Attribute msg
 comboBox =
     role Combobox
 
 
 {-| Add `role="definition"` to the attributes of an element.
 -}
-definition : Html.Attribute Never
+definition : Html.Attribute msg
 definition =
     role Definition
 
 
 {-| Add `role="dialog"` to the attributes of an element.
 -}
-dialog : Html.Attribute Never
+dialog : Html.Attribute msg
 dialog =
     role Dialog
 
 
 {-| Add `role="directory"` to the attributes of an element.
 -}
-directory : Html.Attribute Never
+directory : Html.Attribute msg
 directory =
     role Directory
 
 
 {-| Add `role="document"` to the attributes of an element.
 -}
-document : Html.Attribute Never
+document : Html.Attribute msg
 document =
     role Document
 
 
 {-| Add `role="grid"` to the attributes of an element.
 -}
-grid : Html.Attribute Never
+grid : Html.Attribute msg
 grid =
     role Grid
 
 
 {-| Add `role="gridcell"` to the attributes of an element.
 -}
-gridCell : Html.Attribute Never
+gridCell : Html.Attribute msg
 gridCell =
     role Gridcell
 
 
 {-| Define a set of controls. (for a group of radio inputs, see radioGroup).
 -}
-group : Html.Attribute Never
+group : Html.Attribute msg
 group =
     role Group
 
@@ -247,265 +247,265 @@ Really this attribute should only be necessary if you need an `h7`-type heading.
     div [ heading, level 7 ] []
 
 -}
-heading : Html.Attribute Never
+heading : Html.Attribute msg
 heading =
     role Heading
 
 
 {-| Add `role="img"` to the attributes of an element.
 -}
-img : Html.Attribute Never
+img : Html.Attribute msg
 img =
     role Img
 
 
 {-| Add `role="link"` to the attributes of an element.
 -}
-link : Html.Attribute Never
+link : Html.Attribute msg
 link =
     role Link
 
 
 {-| Add `role="list"` to the attributes of an element.
 -}
-list : Html.Attribute Never
+list : Html.Attribute msg
 list =
     role List
 
 
 {-| Add `role="listbox"` to the attributes of an element.
 -}
-listBox : Html.Attribute Never
+listBox : Html.Attribute msg
 listBox =
     role Listbox
 
 
 {-| Add `role="listitem"` to the attributes of an element.
 -}
-listItem : Html.Attribute Never
+listItem : Html.Attribute msg
 listItem =
     role Listitem
 
 
 {-| Add `role="log"` to the attributes of an element.
 -}
-log : Html.Attribute Never
+log : Html.Attribute msg
 log =
     role Log
 
 
 {-| Add `role="marquee"` to the attributes of an element.
 -}
-marquee : Html.Attribute Never
+marquee : Html.Attribute msg
 marquee =
     role Marquee
 
 
 {-| Add `role="math"` to the attributes of an element.
 -}
-math : Html.Attribute Never
+math : Html.Attribute msg
 math =
     role Math
 
 
 {-| Add `role="menu"` to the attributes of an element.
 -}
-menu : Html.Attribute Never
+menu : Html.Attribute msg
 menu =
     role Menu
 
 
 {-| Add `role="menubar"` to the attributes of an element.
 -}
-menuBar : Html.Attribute Never
+menuBar : Html.Attribute msg
 menuBar =
     role Menubar
 
 
 {-| Add `role="menuitem"` to the attributes of an element.
 -}
-menuItem : Html.Attribute Never
+menuItem : Html.Attribute msg
 menuItem =
     role Menuitem
 
 
 {-| Add `role="menuitemcheckbox"` to the attributes of an element.
 -}
-menuItemCheckBox : Html.Attribute Never
+menuItemCheckBox : Html.Attribute msg
 menuItemCheckBox =
     role Menuitemcheckbox
 
 
 {-| Add `role="menuitemradio"` to the attributes of an element.
 -}
-menuItemRadio : Html.Attribute Never
+menuItemRadio : Html.Attribute msg
 menuItemRadio =
     role Menuitemradio
 
 
 {-| Add `role="note"` to the attributes of an element.
 -}
-note : Html.Attribute Never
+note : Html.Attribute msg
 note =
     role Note
 
 
 {-| Add `role="option"` to the attributes of an element.
 -}
-option : Html.Attribute Never
+option : Html.Attribute msg
 option =
     role Option
 
 
 {-| Sets role presentation.
 -}
-presentation : Html.Attribute Never
+presentation : Html.Attribute msg
 presentation =
     role Presentation
 
 
 {-| Add `role="progressbar"` to the attributes of an element.
 -}
-progressBar : Html.Attribute Never
+progressBar : Html.Attribute msg
 progressBar =
     role Progressbar
 
 
 {-| Add `role="radio"` to the attributes of an element.
 -}
-radio : Html.Attribute Never
+radio : Html.Attribute msg
 radio =
     role Radio
 
 
 {-| Define a set of radio-controls.
 -}
-radioGroup : Html.Attribute Never
+radioGroup : Html.Attribute msg
 radioGroup =
     role Radiogroup
 
 
 {-| Add `role="row"` to the attributes of an element.
 -}
-row : Html.Attribute Never
+row : Html.Attribute msg
 row =
     role Row
 
 
 {-| Add `role="rowgroup"` to the attributes of an element.
 -}
-rowGroup : Html.Attribute Never
+rowGroup : Html.Attribute msg
 rowGroup =
     role Rowgroup
 
 
 {-| Add `role="rowheader"` to the attributes of an element.
 -}
-rowHeader : Html.Attribute Never
+rowHeader : Html.Attribute msg
 rowHeader =
     role Rowheader
 
 
 {-| Add `role="scrollbar"` to the attributes of an element.
 -}
-scrollBar : Html.Attribute Never
+scrollBar : Html.Attribute msg
 scrollBar =
     role Scrollbar
 
 
 {-| Add `role="separator"` to the attributes of an element.
 -}
-separator : Html.Attribute Never
+separator : Html.Attribute msg
 separator =
     role Separator
 
 
 {-| Add `role="slider"` to the attributes of an element.
 -}
-slider : Html.Attribute Never
+slider : Html.Attribute msg
 slider =
     role Slider
 
 
 {-| Add `role="spinbutton"` to the attributes of an element.
 -}
-spinButton : Html.Attribute Never
+spinButton : Html.Attribute msg
 spinButton =
     role Spinbutton
 
 
 {-| Add `role="status"` to the attributes of an element.
 -}
-status : Html.Attribute Never
+status : Html.Attribute msg
 status =
     role Status
 
 
 {-| Add `role="tab"` to the attributes of an element.
 -}
-tab : Html.Attribute Never
+tab : Html.Attribute msg
 tab =
     role Tab
 
 
 {-| Add `role="tablist"` to the attributes of an element.
 -}
-tabList : Html.Attribute Never
+tabList : Html.Attribute msg
 tabList =
     role Tablist
 
 
 {-| Add `role="tabpanel"` to the attributes of an element.
 -}
-tabPanel : Html.Attribute Never
+tabPanel : Html.Attribute msg
 tabPanel =
     role Tabpanel
 
 
 {-| Add `role="textbox"` to the attributes of an element.
 -}
-textBox : Html.Attribute Never
+textBox : Html.Attribute msg
 textBox =
     role Textbox
 
 
 {-| Add `role="timer"` to the attributes of an element.
 -}
-timer : Html.Attribute Never
+timer : Html.Attribute msg
 timer =
     role Timer
 
 
 {-| Add `role="toolbar"` to the attributes of an element.
 -}
-toolBar : Html.Attribute Never
+toolBar : Html.Attribute msg
 toolBar =
     role Toolbar
 
 
 {-| Add `role="tooltip"` to the attributes of an element.
 -}
-toolTip : Html.Attribute Never
+toolTip : Html.Attribute msg
 toolTip =
     role Tooltip
 
 
 {-| Add `role="tree"` to the attributes of an element.
 -}
-tree : Html.Attribute Never
+tree : Html.Attribute msg
 tree =
     role Tree
 
 
 {-| Add `role="treegrid"` to the attributes of an element.
 -}
-treeGrid : Html.Attribute Never
+treeGrid : Html.Attribute msg
 treeGrid =
     role Treegrid
 
 
 {-| Add `role="treeitem"` to the attributes of an element.
 -}
-treeItem : Html.Attribute Never
+treeItem : Html.Attribute msg
 treeItem =
     role Treeitem

--- a/src/Accessibility/Style.elm
+++ b/src/Accessibility/Style.elm
@@ -20,7 +20,7 @@ import Html.Attributes
     label [ invisible ] [ text "Screen readers can still read me!" ]
 
 -}
-invisible : Html.Attribute Never
+invisible : Html.Attribute msg
 invisible =
     Html.Attributes.style
         [ ( "property", "clip rect(1px, 1px, 1px, 1px)" )

--- a/src/Accessibility/Utils.elm
+++ b/src/Accessibility/Utils.elm
@@ -7,7 +7,7 @@ import Html.Attributes exposing (..)
 -- ARIA
 
 
-aria : String -> String -> Html.Attribute Never
+aria : String -> String -> Html.Attribute msg
 aria =
     attribute << (++) "aria-"
 
@@ -44,7 +44,7 @@ nonInteractive =
 -- ROLE
 
 
-role : Role -> Html.Attribute Never
+role : Role -> Html.Attribute msg
 role role_ =
     attribute "role" <| roleToString role_
 

--- a/src/Accessibility/Widget.elm
+++ b/src/Accessibility/Widget.elm
@@ -130,7 +130,7 @@ in the line that the user is completing.
 Be sure to indicate that the auto-completed text is selected.
 
 -}
-autoCompleteInline : Html.Attribute Never
+autoCompleteInline : Html.Attribute msg
 autoCompleteInline =
     aria "autocomplete" "inline"
 
@@ -144,7 +144,7 @@ Be sure to indicate that the auto-completed text is selected.
 See [the autocomplete spec](https://www.w3.org/TR/wai-aria-1.1/#aria-autocomplete).
 
 -}
-autoCompleteList : Html.Attribute Never
+autoCompleteList : Html.Attribute msg
 autoCompleteList =
     aria "autocomplete" "list"
 
@@ -158,7 +158,7 @@ Be sure to indicate that the auto-completed text is selected.
 See [the autocomplete spec](https://www.w3.org/TR/wai-aria-1.1/#aria-autocomplete).
 
 -}
-autoCompleteBoth : Html.Attribute Never
+autoCompleteBoth : Html.Attribute msg
 autoCompleteBoth =
     aria "autocomplete" "both"
 
@@ -171,21 +171,21 @@ Other elements won't support tri-state checkedness.
 See [the checked spec](https://www.w3.org/TR/wai-aria-1.1/#aria-checked).
 
 -}
-checked : Maybe Bool -> Html.Attribute Never
+checked : Maybe Bool -> Html.Attribute msg
 checked =
     aria "checked" << toTriStateString
 
 
 {-| Sets the indeterminate value to be true.
 -}
-indeterminate : Html.Attribute Never
+indeterminate : Html.Attribute msg
 indeterminate =
     property "indeterminate" (Json.Encode.bool True)
 
 
 {-| Supported for all elements. Elements are not disabled (are enabled) by default.
 -}
-disabled : Bool -> Html.Attribute Never
+disabled : Bool -> Html.Attribute msg
 disabled =
     aria "disabled" << toBoolString
 
@@ -197,7 +197,7 @@ expanded/collapsed, OR to an elment it controls that is either expanded/collapse
 In the latter case, throw on a `controls` attribute as well to clarify the relationship.
 
 -}
-expanded : Bool -> Html.Attribute Never
+expanded : Bool -> Html.Attribute msg
 expanded =
     aria "expanded" << toBoolString
 
@@ -207,7 +207,7 @@ expanded =
 Be careful while managing focus and triggering.
 
 -}
-hasMenuPopUp : Html.Attribute Never
+hasMenuPopUp : Html.Attribute msg
 hasMenuPopUp =
     aria "haspopup" "menu"
 
@@ -217,7 +217,7 @@ hasMenuPopUp =
 Be careful while managing focus and triggering.
 
 -}
-hasListBoxPopUp : Html.Attribute Never
+hasListBoxPopUp : Html.Attribute msg
 hasListBoxPopUp =
     aria "haspopup" "listbox"
 
@@ -227,7 +227,7 @@ hasListBoxPopUp =
 Be careful while managing focus and triggering.
 
 -}
-hasTreePopUp : Html.Attribute Never
+hasTreePopUp : Html.Attribute msg
 hasTreePopUp =
     aria "haspopup" "tree"
 
@@ -237,7 +237,7 @@ hasTreePopUp =
 Be careful while managing focus and triggering.
 
 -}
-hasGridPopUp : Html.Attribute Never
+hasGridPopUp : Html.Attribute msg
 hasGridPopUp =
     aria "haspopup" "grid"
 
@@ -247,13 +247,13 @@ hasGridPopUp =
 Be careful while managing focus and triggering.
 
 -}
-hasDialogPopUp : Html.Attribute Never
+hasDialogPopUp : Html.Attribute msg
 hasDialogPopUp =
     aria "haspopup" "dialog"
 
 
 {-| -}
-hidden : Bool -> Html.Attribute Never
+hidden : Bool -> Html.Attribute msg
 hidden =
     aria "hidden" << toBoolString
 
@@ -263,28 +263,28 @@ hidden =
 For invalid grammar or spelling, please see `invalidGrammar` and `invalidSpelling` respectively.
 
 -}
-invalid : Bool -> Html.Attribute Never
+invalid : Bool -> Html.Attribute msg
 invalid =
     aria "invalid" << toBoolString
 
 
 {-| Supported for all elements.
 -}
-invalidGrammar : Html.Attribute Never
+invalidGrammar : Html.Attribute msg
 invalidGrammar =
     aria "invalid" "grammar"
 
 
 {-| Supported for all elements.
 -}
-invalidSpelling : Html.Attribute Never
+invalidSpelling : Html.Attribute msg
 invalidSpelling =
     aria "invalid" "spelling"
 
 
 {-| Supported for all elements.
 -}
-label : String -> Html.Attribute Never
+label : String -> Html.Attribute msg
 label =
     aria "label"
 
@@ -298,7 +298,7 @@ refer to the [documentation](https://www.w3.org/TR/wai-aria-1.1/#aria-level) to 
         div (heading :: level 7 :: attributes)
 
 -}
-level : Int -> Html.Attribute Never
+level : Int -> Html.Attribute msg
 level =
     aria "level" << toString
 
@@ -320,7 +320,7 @@ interactable.
             ]
 
 -}
-modal : Bool -> Html.Attribute Never
+modal : Bool -> Html.Attribute msg
 modal =
     aria "modal" << toBoolString
 
@@ -333,7 +333,7 @@ Careful of default keyboard behavior when coupling this property with text input
 which by default submit their form group on enter.
 
 -}
-multiLine : Bool -> Html.Attribute Never
+multiLine : Bool -> Html.Attribute msg
 multiLine =
     aria "multiline" << toBoolString
 
@@ -344,7 +344,7 @@ for a `tabList`, say, to have multiple selectable descendants?)
 When true, users are not restricted to selecting only one selectable descendant at a time.
 
 -}
-multiSelectable : Bool -> Html.Attribute Never
+multiSelectable : Bool -> Html.Attribute msg
 multiSelectable =
     aria "multiselectable" << toBoolString
 
@@ -355,7 +355,7 @@ multiSelectable =
 Careful: default behavior is inconsistent across those roles.
 
 -}
-orientationHorizontal : Html.Attribute Never
+orientationHorizontal : Html.Attribute msg
 orientationHorizontal =
     --TODO: should the non-default behavior be explicit from the role perspective?
     aria "orientation" "horizontal"
@@ -367,7 +367,7 @@ orientationHorizontal =
 Careful: default behavior is inconsistent across those roles.
 
 -}
-orientationVertical : Html.Attribute Never
+orientationVertical : Html.Attribute msg
 orientationVertical =
     --TODO: should the non-default behavior be explicit from the role perspective?
     aria "orientation" "vertical"
@@ -386,7 +386,7 @@ as well.
         [ text "This button should be styled for site viewers such that it's clear it's pressed!" ]
 
 -}
-pressed : Maybe Bool -> Html.Attribute Never
+pressed : Maybe Bool -> Html.Attribute msg
 pressed =
     --TODO: Move to be a button role option?
     aria "pressed" << toTriStateString
@@ -400,7 +400,7 @@ copying behavior should apply. (Read: `readOnly` elements are navigable but
 unchangeable, and `disabled` elements are neither navigable nor unchangebale).
 
 -}
-readOnly : Bool -> Html.Attribute Never
+readOnly : Bool -> Html.Attribute msg
 readOnly =
     aria "readonly" << toBoolString
 
@@ -410,7 +410,7 @@ readOnly =
 Indicate whether user input is or is not required on a field for valid form submission.
 
 -}
-required : Bool -> Html.Attribute Never
+required : Bool -> Html.Attribute msg
 required =
     aria "required" << toBoolString
 
@@ -420,7 +420,7 @@ required =
 Indicate whether an element (in a single- or multi-selectable widget) is or is not selected.
 
 -}
-selected : Bool -> Html.Attribute Never
+selected : Bool -> Html.Attribute msg
 selected =
     aria "selected" << toBoolString
 
@@ -433,7 +433,7 @@ This should only be applied to one header at a time.
 Table is sorted by this column's values in ascending order.
 
 -}
-sortAscending : Html.Attribute Never
+sortAscending : Html.Attribute msg
 sortAscending =
     aria "sort" "ascending"
 
@@ -446,7 +446,7 @@ Only one column in a table should be sorting the values in table.
 Table is sorted by this column's values in descending order.
 
 -}
-sortDescending : Html.Attribute Never
+sortDescending : Html.Attribute msg
 sortDescending =
     aria "sort" "descending"
 
@@ -460,7 +460,7 @@ Table is sorted by this column's values, but the algorithm for that sorting
 is custom (not ascending or descending).
 
 -}
-sortCustom : Html.Attribute Never
+sortCustom : Html.Attribute msg
 sortCustom =
     aria "sort" "other"
 
@@ -471,7 +471,7 @@ used on table or grid headers.
 Table is not sorted by this column's values.
 
 -}
-sortNone : Html.Attribute Never
+sortNone : Html.Attribute msg
 sortNone =
     aria "sort" "none"
 
@@ -481,7 +481,7 @@ sortNone =
 Set the max allowed value for a range widget.
 
 -}
-valueMax : number -> Html.Attribute Never
+valueMax : number -> Html.Attribute msg
 valueMax =
     aria "valuemax" << toString
 
@@ -491,7 +491,7 @@ valueMax =
 Set the min allowed value for a range widget.
 
 -}
-valueMin : number -> Html.Attribute Never
+valueMin : number -> Html.Attribute msg
 valueMin =
     aria "valuemin" << toString
 
@@ -501,7 +501,7 @@ valueMin =
 Set the current value for a range widget. Don't use this property for indeterminate states.
 
 -}
-valueNow : number -> Html.Attribute Never
+valueNow : number -> Html.Attribute msg
 valueNow =
     aria "valuenow" << toString
 
@@ -512,6 +512,6 @@ This property takes precedence over `valueNow`, and should show a human-readable
 version of the current value. However, `valueNow` should always be used.
 
 -}
-valueText : String -> Html.Attribute Never
+valueText : String -> Html.Attribute msg
 valueText =
     aria "valuetext"


### PR DESCRIPTION
This prevents requiring:

```
view = 
    div
            [ class "inexplicable-content"
            , Html.Attributes.map never (describedBy ["awesome-tooltip-numbah-1"])
            ]
```