### PR TITLE
Upgrade part 2

### DIFF
--- a/src/Accessibility.elm
+++ b/src/Accessibility.elm
@@ -2,14 +2,14 @@ module Accessibility exposing
     ( labelBefore, labelAfter, labelHidden
     , inputText, radio, checkbox
     , tabList, tab, tabPanel
-    , img, decorativeImg, figure
+    , img, decorativeImg
     , button, textarea, select
     , text
     , h1, h2, h3, h4, h5, h6
     , div, p, hr, pre, blockquote
     , span, a, code, em, strong, i, b, u, sub, sup, br
     , ol, ul, li, dl, dt, dd
-    , img, iframe, canvas, math
+    , iframe, canvas, math
     , form, option
     , section, nav, article, aside, header, footer, address, main_
     , figure, figcaption
@@ -103,7 +103,7 @@ Remember, **redundant** information can be confusing too.
             , decorativeImg [ src "smiling_family.jpg" ]
             ]
 
-@docs img, decorativeImg, figure
+@docs img, decorativeImg
 
 
 ## From [Html](http://package.elm-lang.org/packages/elm/html/latest)
@@ -125,7 +125,7 @@ These elements will prevent you from adding event listeners.
 @docs div, p, hr, pre, blockquote
 @docs span, a, code, em, strong, i, b, u, sub, sup, br
 @docs ol, ul, li, dl, dt, dd
-@docs img, iframe, canvas, math
+@docs iframe, canvas, math
 @docs form, option
 @docs section, nav, article, aside, header, footer, address, main_
 @docs figure, figcaption

--- a/src/Accessibility/Aria.elm
+++ b/src/Accessibility/Aria.elm
@@ -109,7 +109,7 @@ displayed. (If all columns are present--skip using this.)
 -}
 colCount : Int -> Html.Attribute msg
 colCount =
-    aria "colcount" << toString
+    aria "colcount" << String.fromInt
 
 
 {-| Supported by `cell`, `row`, `columnHeader`, `gridCell`, and `rowHeader`.
@@ -122,7 +122,7 @@ The simplest rule is to put the `colIndex` on every child of a `row`.
 -}
 colIndex : Int -> Html.Attribute msg
 colIndex =
-    aria "colindex" << toString
+    aria "colindex" << String.fromInt
 
 
 {-| Supported by `cell`, `columnHeader`, `gridCell`, and `rowHeader`.
@@ -132,7 +132,7 @@ Indicate how many columns-wide a cell is.
 -}
 colSpan : Int -> Html.Attribute msg
 colSpan =
-    aria "colspan" << toString
+    aria "colspan" << String.fromInt
 
 
 {-| Supported by `table`, `grid`, `treegrid`.
@@ -145,7 +145,7 @@ displayed. (If all rows are present--skip using this.)
 -}
 rowCount : Int -> Html.Attribute msg
 rowCount =
-    aria "rowcount" << toString
+    aria "rowcount" << String.fromInt
 
 
 {-| Supported by `cell`, `row`, `columnHeader`, `gridCell`, and `rowHeader`.
@@ -155,7 +155,7 @@ Analagous to `colIndex`.
 -}
 rowIndex : Int -> Html.Attribute msg
 rowIndex =
-    aria "rowindex" << toString
+    aria "rowindex" << String.fromInt
 
 
 {-| Supported by `cell`, `columnHeader`, `gridCell`, and `rowHeader`.
@@ -165,7 +165,7 @@ Indicate how many rows-wide a cell is.
 -}
 rowSpan : Int -> Html.Attribute msg
 rowSpan =
-    aria "rowspan" << toString
+    aria "rowspan" << String.fromInt
 
 
 {-| Supported by list-y elements: `article`, `listItem`, `menuItem`, `option`,
@@ -176,7 +176,7 @@ Only necessary when not all of the items in the set are in the DOM. Use with `se
 -}
 posInSet : Int -> Html.Attribute msg
 posInSet =
-    aria "posinset" << toString
+    aria "posinset" << String.fromInt
 
 
 {-| Supported by list-y elements: `article`, `listItem`, `menuItem`, `option`,
@@ -188,7 +188,7 @@ currently present in the DOM.
 -}
 setSize : Int -> Html.Attribute msg
 setSize =
-    aria "setsize" << toString
+    aria "setsize" << String.fromInt
 
 
 {-| Creates aria controls attribute. Pass the unique string id of whatever is being controlled.


### PR DESCRIPTION
Apparently I was really relying on the tests to catch my mistakes 😅. Missed a couple of compilation errors.

This PR fixes doubled-up exports in `Accessibility` and fixes uses of `toString` in `Accessibility.Aria`.