### PR TITLE
Fix a tab component view example

### DIFF
--- a/src/Accessibility.elm
+++ b/src/Accessibility.elm
@@ -46,7 +46,8 @@ more options.
 Together, `tabList`, `tab`, and `tabPanel` describe the pieces of a tab component view.
 
     import Accessibility exposing (Html, tab, tabList, tabPanel, text)
-    import Accessibility.Widget exposing (controls, hidden, labelledBy, selected)
+    import Accessibility.Aria exposing (controls, labelledBy)
+    import Accessibility.Widget exposing (hidden, selected)
     import Html.Attributes exposing (id)
 
     view : Html msg


### PR DESCRIPTION
Hello! Thank you for this great package.

I noticed that the tabList examples has some mistake namely with imports. So here is a fix for that.

Have a good one.