### PR TITLE
Anchor tags require href specified

### DIFF
--- a/src/Accessibility.elm
+++ b/src/Accessibility.elm
@@ -653,10 +653,14 @@ div attributes =
 
 {-| `a` should generally not have event listeners. If you _really_ need to add
 an event listener, use the elm/html library instead.
+This tag will not let you have `a` without the href attribute.
+
+    a "/products?sortBy=price" [ class "products-link" ] [ text "sorted products" ]
+
 -}
-a : List (Attribute Never) -> List (Html msg) -> Html msg
-a attributes =
-    Html.a (nonInteractive attributes)
+a : String -> List (Attribute Never) -> List (Html msg) -> Html msg
+a href_ attributes =
+    Html.a (Html.Attributes.href href_ :: nonInteractive attributes)
 
 
 {-| `em` should generally not have event listeners. If you _really_ need to add

--- a/tests/AccessibilitySpec.elm
+++ b/tests/AccessibilitySpec.elm
@@ -1,4 +1,4 @@
-module AccessibilitySpec exposing (htmlSpec, imageSpec, inputSpec)
+module AccessibilitySpec exposing (anchorSpec, htmlSpec, imageSpec, inputSpec)
 
 import Accessibility exposing (..)
 import Html.Attributes as Attribute
@@ -7,6 +7,24 @@ import Test exposing (..)
 import Test.Html.Event as Event
 import Test.Html.Query as Query
 import Test.Html.Selector as Selector
+
+
+anchorSpec : Test
+anchorSpec =
+    let
+        anchor =
+            div [] [ Accessibility.a "/hello-world" [] [] ]
+    in
+    describe "anchors" <|
+        [ describe "a"
+            [ test "has href" <|
+                \() ->
+                    anchor
+                        |> Query.fromHtml
+                        |> Query.find [ Selector.tag "a" ]
+                        |> Query.has [ Selector.attribute <| Attribute.href "/hello-world" ]
+            ]
+        ]
 
 
 inputSpec : Test


### PR DESCRIPTION
Hello! This PR follows an example of `img`. With this change anchor tags require the href attribute to be specified. I think it doesn't make sense to have something like`<a href="">stuff</a>`. So now people have to write code like so:

```elm
a "/hello" [ class "blah-blah"] [ text "see hello" ]
```