### PR TITLE
bump elm version in examples to 0.19.1; stop using Accessibility.Widget

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -13,7 +13,7 @@
         "Accessibility.Role",
         "Accessibility.Style"
     ],
-    "elm-version": "0.19.0 <= v < 0.20.0",
+    "elm-version": "0.19.1 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -4,7 +4,7 @@
         "src",
         "../src"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "elm/browser": "1.0.1",

--- a/examples/src/Views/Tabs.elm
+++ b/examples/src/Views/Tabs.elm
@@ -9,7 +9,6 @@ module Views.Tabs exposing (Model, view, update, Msg(..))
 import Accessibility as Html exposing (..)
 import Accessibility.Aria exposing (controls, labelledBy)
 import Accessibility.Key exposing (enter, left, onKeyDown, right)
-import Accessibility.Widget exposing (hidden, selected)
 import Html.Attributes exposing (class, classList, id, style)
 import Html.Events exposing (onClick)
 import List.Zipper as Zipper exposing (Zipper)
@@ -84,8 +83,7 @@ viewTab groupId { tabContent, isSelected, section, identifier } =
             , left SelectPreviousTab
             , right SelectNextTab
             ]
-         , controls (panelId groupId section identifier)
-         , selected isSelected
+         , controls [panelId groupId section identifier]
          ]
             ++ tabStyles
         )
@@ -106,7 +104,6 @@ viewPanel groupId { panelContent, isSelected, section, identifier } =
     tabPanel
         ([ id (panelId groupId section identifier)
          , labelledBy (tabId groupId section identifier)
-         , hidden (not isSelected)
          , Html.Attributes.hidden (not isSelected)
          ]
             ++ panelStyles


### PR DESCRIPTION
Needed these to be able to develop locally. 